### PR TITLE
graph2cwl.xsl: Fix shellpath default value

### DIFF
--- a/stylesheets/graph2cwl.xsl
+++ b/stylesheets/graph2cwl.xsl
@@ -6,7 +6,7 @@
 	>
 <!-- convert a xml-make to CWL https://github.com/common-workflow-language -->
 <xsl:output method="text"/>
-<xsl:param name="shellpath">~/src/xml-patch-make/tmp/graph2cwl.bash</xsl:param>
+<xsl:param name="shellpath">graph2cwl.bash</xsl:param>
 <xsl:key name="tt" match="target" use="@id" />
 
 <!-- pour memoire  : /home/lindenb/.local/bin/cwl-runner -->


### PR DESCRIPTION
Create graph2cwl.bash in the current working directory.