### PR TITLE
add Dockerfile to build xml-make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:stretch
+MAINTAINER Chris Mungall <cjmungall@lbl.gov>
+
+RUN apt-get update && apt-get -y install autoconf build-essential
+RUN apt-get install -y pkg-config
+
+WORKDIR /xml-make
+COPY . /xml-make
+RUN make
+CMD ./make-4.1/bin/xml-make4.1


### PR DESCRIPTION
See https://github.com/common-workflow-lab/make2cwl/issues/1

I will also release this to Dockerhub

Note to self - execute using:

```
docker run -v $PWD/:/work -w /work --rm -ti xml-make /xml-make/make-4.1/bin/xml-make4.1 "$@"
```

cc @mr-c 